### PR TITLE
Fix for matchers NonExhaustiveMatchError error and new failure matcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,10 @@
 PATH
   remote: ../trailblazer
   specs:
-    trailblazer (2.0.0.beta1)
+    trailblazer (2.0.6)
       declarative
       reform (>= 2.2.0, < 3.0.0)
-      trailblazer-operation
-      uber (>= 0.1.0, < 0.2.0)
+      trailblazer-operation (>= 0.0.12, < 0.1.0)
 
 PATH
   remote: .
@@ -17,12 +16,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     concurrent-ruby (1.0.2)
-    declarative (0.0.8)
-      uber (>= 0.0.15)
-    disposable (0.3.2)
-      declarative (>= 0.0.8, < 1.0.0)
+    declarative (0.0.9)
+    declarative-builder (0.1.0)
+      declarative-option (< 0.2.0)
+    declarative-option (0.1.0)
+    disposable (0.4.3)
+      declarative (>= 0.0.9, < 1.0.0)
+      declarative-builder (< 0.2.0)
+      declarative-option (< 0.2.0)
       representable (>= 2.4.0, <= 3.1.0)
-      uber
+      uber (< 0.2.0)
     dry-configurable (0.3.0)
       concurrent-ruby (~> 1.0)
     dry-container (0.5.0)
@@ -57,19 +60,19 @@ GEM
     minitest-line (0.6.3)
       minitest (~> 5.0)
     multi_json (1.12.1)
-    pipetree (0.0.4)
+    pipetree (0.1.1)
     rake (11.3.0)
-    reform (2.2.3)
-      disposable (>= 0.3.0, < 0.4.0)
+    reform (2.2.4)
+      disposable (>= 0.4.1)
       representable (>= 2.4.0, < 3.1.0)
-      uber (>= 0.0.15, < 0.2.0)
-    representable (3.0.2)
-      declarative (~> 0.0.5)
-      uber (>= 0.0.15, < 0.2.0)
-    trailblazer-operation (0.0.6)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    trailblazer-operation (0.0.13)
       declarative
-      pipetree (>= 0.0.4, < 0.1.0)
-      uber (>= 0.1.0, < 0.2.0)
+      pipetree (>= 0.1.1, < 0.2.0)
+      uber
     uber (0.1.0)
 
 PLATFORMS
@@ -86,4 +89,4 @@ DEPENDENCIES
   trailblazer-endpoint!
 
 BUNDLED WITH
-   1.12.5
+   1.14.6

--- a/lib/trailblazer/endpoint.rb
+++ b/lib/trailblazer/endpoint.rb
@@ -19,10 +19,13 @@ module Trailblazer
         resolve: ->(result) { result }),
       # TODO: we could add unauthorized here.
       unauthenticated: Dry::Matcher::Case.new(
-        match:   ->(result) { result.failure? && result["result.policy.default"].failure? }, # FIXME: we might need a &. here ;)
+        match:   ->(result) { result.failure? && result["result.policy.default"] && result["result.policy.default"].failure? },
         resolve: ->(result) { result }),
       invalid: Dry::Matcher::Case.new(
         match:   ->(result) { result.failure? && result["result.contract.default"] && result["result.contract.default"].failure? },
+        resolve: ->(result) { result }),
+      failure: Dry::Matcher::Case.new(
+        match:   ->(result) { result.failure? },
         resolve: ->(result) { result })
     )
 

--- a/lib/trailblazer/endpoint.rb
+++ b/lib/trailblazer/endpoint.rb
@@ -38,6 +38,7 @@ module Trailblazer
     def call(result, handlers=nil, &block)
       matcher.(result, &block) and return if block_given? # evaluate user blocks first.
       matcher.(result, &handlers)     # then, generic Rails handlers in controller context.
+      rescue Dry::Matcher::NonExhaustiveMatchError # tmp solution, need to figure our how to handle NonExhaustiveMatchError errors
     end
 
     def matcher

--- a/lib/trailblazer/endpoint/rails.rb
+++ b/lib/trailblazer/endpoint/rails.rb
@@ -21,6 +21,7 @@ module Trailblazer::Endpoint::Handlers
         m.created         { |result| controller.head 201, location: "#{@path}/#{result["model"].id}" }#, result["representer.serializer.class"].new(result["model"]).to_json
         m.success         { |result| controller.head 200, location: "#{@path}/#{result["model"].id}" }
         m.invalid         { |result| controller.render json: result["representer.errors.class"].new(result['result.contract.default'].errors).to_json, status: 422 }
+        m.failure         { |result| controller.render json: { :error=>"unknown error" }, status: 422 }
       end
     end
   end

--- a/test/rails-app/Gemfile
+++ b/test/rails-app/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 # Use sqlite3 as the database for Active Record
@@ -10,8 +9,7 @@ gem 'sqlite3'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "trailblazer-endpoint", path: "../../."
-gem "trailblazer", path: "../../../trailblazer"
-gem "trailblazer-operation", path: "../../../operation"
-# gem "trailblazer-rails"
+gem "trailblazer"
+gem "trailblazer-operation"
 
 gem "multi_json"

--- a/test/rails-app/Gemfile.lock
+++ b/test/rails-app/Gemfile.lock
@@ -1,22 +1,5 @@
 PATH
-  remote: ../../../operation
-  specs:
-    trailblazer-operation (0.0.6)
-      declarative
-      pipetree (>= 0.0.4, < 0.1.0)
-      uber (>= 0.1.0, < 0.2.0)
-
-PATH
-  remote: ../../../trailblazer
-  specs:
-    trailblazer (2.0.0.beta1)
-      declarative
-      reform (>= 2.2.0, < 3.0.0)
-      trailblazer-operation
-      uber (>= 0.1.0, < 0.2.0)
-
-PATH
-  remote: ../../.
+  remote: ../..
   specs:
     trailblazer-endpoint (0.0.1)
       dry-matcher
@@ -64,12 +47,16 @@ GEM
     arel (7.1.4)
     builder (3.2.2)
     concurrent-ruby (1.0.2)
-    declarative (0.0.8)
-      uber (>= 0.0.15)
-    disposable (0.3.2)
-      declarative (>= 0.0.8, < 1.0.0)
+    declarative (0.0.9)
+    declarative-builder (0.1.0)
+      declarative-option (< 0.2.0)
+    declarative-option (0.1.0)
+    disposable (0.4.3)
+      declarative (>= 0.0.9, < 1.0.0)
+      declarative-builder (< 0.2.0)
+      declarative-option (< 0.2.0)
       representable (>= 2.4.0, <= 3.1.0)
-      uber
+      uber (< 0.2.0)
     dry-matcher (0.5.0)
     erubis (2.7.0)
     globalid (0.3.7)
@@ -89,7 +76,7 @@ GEM
     nio4r (1.2.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-    pipetree (0.0.4)
+    pipetree (0.1.1)
     rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -117,13 +104,13 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.3.0)
-    reform (2.2.3)
-      disposable (>= 0.3.0, < 0.4.0)
+    reform (2.2.4)
+      disposable (>= 0.4.1)
       representable (>= 2.4.0, < 3.1.0)
-      uber (>= 0.0.15, < 0.2.0)
-    representable (3.0.2)
-      declarative (~> 0.0.5)
-      uber (>= 0.0.15, < 0.2.0)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -134,6 +121,15 @@ GEM
     sqlite3 (1.3.12)
     thor (0.19.1)
     thread_safe (0.3.5)
+    trailblazer (2.0.0)
+      declarative
+      reform (>= 2.2.0, < 3.0.0)
+      trailblazer-operation (>= 0.0.9)
+      uber (>= 0.1.0, < 0.2.0)
+    trailblazer-operation (0.0.13)
+      declarative
+      pipetree (>= 0.1.1, < 0.2.0)
+      uber
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.1.0)
@@ -148,10 +144,10 @@ DEPENDENCIES
   multi_json
   rails (~> 5.0.0, >= 5.0.0.1)
   sqlite3
-  trailblazer!
+  trailblazer
   trailblazer-endpoint!
-  trailblazer-operation!
+  trailblazer-operation
   tzinfo-data
 
 BUNDLED WITH
-   1.12.5
+   1.14.6

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
 require "minitest/autorun"
 require "trailblazer"
-require "trailblazer/endpoint"


### PR DESCRIPTION
I tried to fix few issues I faced with.

First of all, I added extra check for ```result.policy.default``` in ```unauthenticated ``` matcher, cause it failed in cases when there was no policy at all. Actually, I'm not sure about it, because when you are not unauthenticated, you will not get policy to be initialized. Looks like we need more tests here, but since everything failed because of that, this solution is at least something.

I added ```failure``` matcher, because it is possible to have operation without any contracts or policies. In this case, the ```invalid``` matcher will not match, because it's require contract to exist. If you have different opinion about it, I'd like to discuss it, but in my case it helped me.

The most interesting part is ```NonExhaustiveMatchError```. Currently, it will raise the error if don't have ALL handlers in your controller. I'm pretty sure that this solution is not final, but it will help to move forward.

All specs except one are passing. The ```generic handler because user handler doesn't match.``` test is currently failed, because in current realisation matcher will be called with user block if it was pass. But this test expecting generic handlers to be fired if user's handler doesn't match. I think it would be nice to find a solution how return to generic handlers in future, but looks like this case never worked.

I made a lot of changes here only because build was completely broken, so I was in need to update dependencies and change test_helper little bit.

I would like to discuss the future of this gem and all this changes here 😉

P.S. looks like there are fixes for this 3 issues in this PR: https://github.com/trailblazer/trailblazer-endpoint/issues/4,  https://github.com/trailblazer/trailblazer-endpoint/issues/3,  https://github.com/trailblazer/trailblazer-endpoint/issues/2